### PR TITLE
Reset amp control to Y axis / Tone only plays while pen is down.

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,11 @@ run/main_scene="res://world.tscn"
 config/features=PackedStringArray("4.2", "Mobile")
 config/icon="res://icon.svg"
 
+[editor]
+
+version_control/plugin_name="GitPlugin"
+version_control/autoload_on_startup=true
+
 [input]
 
 ui_cancel={

--- a/world.gd
+++ b/world.gd
@@ -41,11 +41,18 @@ func update_tone(event):
 	mouse_pressure = event.pressure
 	mouse_x = event.position.x
 	mouse_y = event.position.y
+	var pendown = null
+	
+	# Check to see if the pen is down.
+	if mouse_pressure > 0: 
+		pendown = 1
+	else:
+		pendown = 0
 	
 	# Remap the mouse position to a pitch and amplitude range
 	frequency = remap(mouse_x, 0, get_viewport().size.x, 10, 1000)
-	# Remap the mouse pressure to 0 and max volume
-	amplitude = remap(mouse_pressure, 0, 1, 0, 5)
+	# Remap the mouse y to 0 and max volume
+	amplitude = remap(mouse_y, 0, get_viewport().size.y, 5, 0) * pendown
 
 func fill_buffer():
 	var increment = frequency / sample_hz


### PR DESCRIPTION
Amplitude has been remapped to Y axis, but a new variable `pen_down` has been created within the `update_tone(event)` function that detects if the stylus is on the tablet. If true, amplitude is multiplied by `1` and if false, amplitude is multiplied by `0`.