### PR TITLE
Remapped frequency to curve

### DIFF
--- a/world.gd
+++ b/world.gd
@@ -7,6 +7,8 @@ var frequency = 0.0
 var amplitude = 0.0
 var phase = 0.0
 
+var string_length # Functions as 'string length' in frequency curve remap equation
+
 # Contians the sound waves
 var playback: AudioStreamPlayback = null
 
@@ -44,8 +46,14 @@ func update_tone(event):
 	
 	var mouse_pressed = ceili(mouse_pressure) # If pressure > 0, then 1
 	
-	# Remap the mouse position to a pitch and amplitude range
-	frequency = remap(mouse_x, 0, get_viewport().size.x, 10, 1000)
+	# Remap mouse x to virtual string length
+	string_length = remap(mouse_x, 0, get_viewport().size.x, 50, 3.125199)
+	#  IMPORTANT: string length of 50 = C2, 3.125... = C6. These values should not be changed without
+	#  first checking the Mersenne curve (see equation below).
+	
+	# string_length integrated into Mersenne's Law for realistic frequency spacing
+	frequency = 8.1763 * (800 / (2 * string_length))
+	
 	# Remap the mouse y to 0 and max volume
 	amplitude = remap(mouse_y, 0, get_viewport().size.y, 5, 0) * mouse_pressed
 


### PR DESCRIPTION
Used Mersenne's Law to remap pitch to a curve - this will make the instrument more intuitive. Frequency range is now between `65.41` Hz and `1046.5` Hz., or C2-C6 (4 octaves). Here is a link to the graph with the curve: [https://www.desmos.com/calculator/mbqta0po1a](url)