### PR TITLE
Adjusted tone curve

### DIFF
--- a/world.gd
+++ b/world.gd
@@ -47,12 +47,12 @@ func update_tone(event):
 	var mouse_pressed = ceili(mouse_pressure) # If pressure > 0, then 1
 	
 	# Remap mouse x to virtual string length
-	string_length = remap(mouse_x, 0, get_viewport().size.x, 50, 3.125199)
-	#  IMPORTANT: string length of 50 = C2, 3.125... = C6. These values should not be changed without
+	string_length = remap(mouse_x, 0, get_viewport().size.x, 100, 21.0225)
+	#  IMPORTANT: string length of 100 = A2, 21.0225 = C5. These values should not be changed without
 	#  first checking the Mersenne curve (see equation below).
 	
 	# string_length integrated into Mersenne's Law for realistic frequency spacing
-	frequency = 8.1763 * (800 / (2 * string_length))
+	frequency = 27.5 * (800 / (2 * string_length))
 	
 	# Remap the mouse y to 0 and max volume
 	amplitude = remap(mouse_y, 0, get_viewport().size.y, 5, 0) * mouse_pressed


### PR DESCRIPTION
Range has been updated to A2 (110 Hz) to C5 (523.25 Hz) and the curve has been tweaked to be more gradual. Updated graph: https://www.desmos.com/calculator/mlfczamksa